### PR TITLE
Add report page with CSV export

### DIFF
--- a/config/optional/system.action.farm_pcsc_csv_action.yml
+++ b/config/optional/system.action.farm_pcsc_csv_action.yml
@@ -1,0 +1,14 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - plan
+    - farm_pcsc
+  enforced:
+    module:
+      - farm_pcsc
+id: farm_pcsc_csv_action
+label: 'Export PCSC CSV'
+type: plan
+plugin: farm_pcsc:csv_action
+configuration: {  }

--- a/config/optional/views.view.pcsc_plan_report.yml
+++ b/config/optional/views.view.pcsc_plan_report.yml
@@ -1,0 +1,700 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - plan.type.pcsc_producer
+  module:
+    - options
+    - plan
+    - user
+id: pcsc_plan_report
+label: 'PCSC Plan Report'
+module: views
+description: ''
+tag: ''
+base_table: plan_field_data
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'PCSC Producers'
+      fields:
+        plan_bulk_form:
+          id: plan_bulk_form
+          table: plan
+          field: plan_bulk_form
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          plugin_id: bulk_form
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          action_title: Action
+          include_exclude: include
+          selected_actions:
+            - farm_pcsc_csv_action
+            - plan_flag_action
+        pcsc_farm_id_value:
+          id: pcsc_farm_id_value
+          table: plan__pcsc_farm_id
+          field: pcsc_farm_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: pcsc_farm_id
+          plugin_id: field
+          label: 'USDA Farm ID'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        name:
+          id: name
+          table: plan_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: null
+          entity_field: name
+          plugin_id: field
+          label: Name
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_state_value:
+          id: pcsc_state_value
+          table: plan__pcsc_state
+          field: pcsc_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: pcsc_state
+          plugin_id: field
+          label: State
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_county_value:
+          id: pcsc_county_value
+          table: plan__pcsc_county
+          field: pcsc_county_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: pcsc_county
+          plugin_id: field
+          label: County
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        flag_value:
+          id: flag_value
+          table: plan__flag
+          field: flag_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: flag
+          plugin_id: field
+          label: Flags
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: mini
+        options:
+          offset: 0
+          items_per_page: 50
+          total_pages: null
+          id: 0
+          tags:
+            next: ››
+            previous: ‹‹
+          expose:
+            items_per_page: true
+            items_per_page_label: 'Items per page'
+            items_per_page_options: '50,100,200,500'
+            items_per_page_options_all: true
+            items_per_page_options_all_label: '- All -'
+            offset: false
+            offset_label: Offset
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view any pcsc_producer plan'
+      cache:
+        type: tag
+        options: {  }
+      empty: {  }
+      sorts: {  }
+      arguments: {  }
+      filters:
+        type:
+          id: type
+          table: plan_field_data
+          field: type
+          entity_type: plan
+          entity_field: type
+          plugin_id: bundle
+          value:
+            pcsc_producer: pcsc_producer
+          group: 1
+        pcsc_farm_id_value:
+          id: pcsc_farm_id_value
+          table: plan__pcsc_farm_id
+          field: pcsc_farm_id_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: pcsc_farm_id
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_farm_id_value_op
+            label: 'USDA Farm ID'
+            description: ''
+            use_operator: false
+            operator: pcsc_farm_id_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_farm_id_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        name:
+          id: name
+          table: plan_field_data
+          field: name
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: name
+          plugin_id: string
+          operator: contains
+          value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: name_op
+            label: Name
+            description: ''
+            use_operator: false
+            operator: name_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: name
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        pcsc_state_value:
+          id: pcsc_state_value
+          table: plan__pcsc_state
+          field: pcsc_state_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan
+          entity_field: pcsc_state
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_state_value_op
+            label: State
+            description: ''
+            use_operator: false
+            operator: pcsc_state_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_state_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            plan_bulk_form: plan_bulk_form
+            pcsc_farm_id_value: pcsc_farm_id_value
+            name: name
+            pcsc_state_value: pcsc_state_value
+            pcsc_county_value: pcsc_county_value
+            flag_value: flag_value
+          default: pcsc_farm_id_value
+          info:
+            plan_bulk_form:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_farm_id_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            name:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_state_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_county_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            flag_value:
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: false
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      header: {  }
+      footer: {  }
+      display_extenders: {  }
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page:
+    id: page
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      display_extenders:
+        collapsible_filter:
+          collapsible: false
+      path: report/pcsc-producers
+    cache_metadata:
+      max-age: 0
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/farm_pcsc.info.yml
+++ b/farm_pcsc.info.yml
@@ -9,4 +9,5 @@ dependencies:
   - farm_land
   - farm_land_types
   - farm_quick
+  - farm_report
   - plan

--- a/farm_pcsc.links.menu.yml
+++ b/farm_pcsc.links.menu.yml
@@ -1,0 +1,4 @@
+farm_pcsc.pcsc_report:
+  title: PCSC Producers
+  parent: farm.report
+  route_name: view.pcsc_plan_report.page

--- a/farm_pcsc.routing.yml
+++ b/farm_pcsc.routing.yml
@@ -1,0 +1,6 @@
+farm_pcsc.csv_action_form:
+  path: '/reports/pcsc/export'
+  defaults:
+    _form: 'Drupal\farm_pcsc\Form\PcscCsvActionForm'
+  requirements:
+    _user_is_logged_in: 'TRUE'

--- a/src/Form/PcscCsvActionForm.php
+++ b/src/Form/PcscCsvActionForm.php
@@ -1,0 +1,311 @@
+<?php
+
+namespace Drupal\farm_pcsc\Form;
+
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\File\FileSystemInterface;
+use Drupal\Core\File\FileUrlGeneratorInterface;
+use Drupal\Core\Form\ConfirmFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Drupal\Core\Url;
+use Drupal\file\FileRepositoryInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\Serializer\SerializerInterface;
+
+/**
+ * Provides a PCSC CSV action form.
+ *
+ * @see \Drupal\farm_export_csv\Plugin\Action\EntityCsv
+ * @see \Drupal\Core\Entity\Form\DeleteMultipleForm
+ */
+class PcscCsvActionForm extends ConfirmFormBase {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $user;
+
+  /**
+   * The tempstore factory.
+   *
+   * @var \Drupal\Core\TempStore\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The serializer service.
+   *
+   * @var \Symfony\Component\Serializer\SerializerInterface
+   */
+  protected $serializer;
+
+  /**
+   * The file system service.
+   *
+   * @var \Drupal\Core\File\FileSystemInterface
+   */
+  protected $fileSystem;
+
+  /**
+   * The file repository service.
+   *
+   * @var \Drupal\file\FileRepositoryInterface
+   */
+  protected $fileRepository;
+
+  /**
+   * The file URL generator.
+   *
+   * @var \Drupal\Core\File\FileUrlGeneratorInterface
+   */
+  protected $fileUrlGenerator;
+
+  /**
+   * The entities to export.
+   *
+   * @var \Drupal\Core\Entity\EntityInterface[]
+   */
+  protected $entities;
+
+  /**
+   * Constructs an PcscCsvActionForm form object.
+   *
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager.
+   * @param \Drupal\Core\Session\AccountInterface $user
+   *   The current user.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Symfony\Component\Serializer\SerializerInterface $serializer
+   *   The serializer service.
+   * @param \Drupal\Core\File\FileSystemInterface $file_system
+   *   The file system service.
+   * @param \Drupal\file\FileRepositoryInterface $file_repository
+   *   The file repository service.
+   * @param \Drupal\Core\File\FileUrlGeneratorInterface $file_url_generator
+   *   The file URL generator.
+   */
+  public function __construct(EntityTypeManagerInterface $entity_type_manager, AccountInterface $user, PrivateTempStoreFactory $temp_store_factory, SerializerInterface $serializer, FileSystemInterface $file_system, FileRepositoryInterface $file_repository, FileUrlGeneratorInterface $file_url_generator) {
+    $this->entityTypeManager = $entity_type_manager;
+    $this->user = $user;
+    $this->tempStore = $temp_store_factory->get('pcsc_csv_confirm');
+    $this->serializer = $serializer;
+    $this->fileSystem = $file_system;
+    $this->fileRepository = $file_repository;
+    $this->fileUrlGenerator = $file_url_generator;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity_type.manager'),
+      $container->get('current_user'),
+      $container->get('tempstore.private'),
+      $container->get('serializer'),
+      $container->get('file_system'),
+      $container->get('file.repository'),
+      $container->get('file_url_generator'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'farm_pcsc_csv_action_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getQuestion() {
+    return $this->formatPlural(count($this->entities), 'Export a CSV of @count item?', 'Export a CSV of @count items?');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getCancelUrl() {
+    return Url::fromUri('plans/pcsc_producer');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getDescription() {
+    return 'This will export a CSV in a format that is compatible with PCSC workbook sheets.';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfirmText() {
+    return $this->t('Export');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state, $entity_type_id = NULL) {
+
+    // Load entities from the temp store and filter out ones that the user
+    // doesn't have access to.
+    $this->entities = [];
+    $inaccessible_entities = [];
+    foreach ($this->tempStore->get($this->user->id()) as $entity) {
+      if (!$entity->access('view', $this->currentUser())) {
+        $inaccessible_entities[] = $entity;
+        continue;
+      }
+      $this->entities[] = $entity;
+    }
+
+    // Add warning message for inaccessible entities.
+    if (!empty($inaccessible_entities)) {
+      $inaccessible_count = count($inaccessible_entities);
+      $this->messenger()->addWarning($this->formatPlural($inaccessible_count, 'Can not export @count item because you do not have the necessary permissions.', 'Can not export @count items because you do not have the necessary permissions.'));
+    }
+
+    // If we don't have a list of entities, redirect.
+    $this->entities = $this->tempStore->get($this->user->id());
+    if (empty($this->entities)) {
+      return new RedirectResponse($this->getCancelUrl()->setAbsolute()->toString());
+    }
+
+    // Delegate to the parent method.
+    $form = parent::buildForm($form, $form_state);
+
+    $form['sheet_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Sheet Type'),
+      '#description' => $this->t('Select the type of workbook sheet to export.'),
+      '#options' => [
+        'all' => $this->t('All'),
+        'enrollment' => $this->t('Enrollment'),
+        'summary' => $this->t('Summary'),
+        'supplemental' => $this->t('Supplemental'),
+      ],
+      '#empty_option' => $this->t('Select one'),
+      '#required' => TRUE,
+    ];
+
+    $form['enrollment_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enrollment sheet'),
+      '#description' => $this->t('Select the enrollment sheet to export.'),
+      '#options' => [
+        'producer' => $this->t('Producer Enrollment'),
+        'field' => $this->t('Field Enrollment'),
+      ],
+      '#states' => [
+        'visible' => [
+          'select[name="sheet_type"]' => ['value' => 'enrollment'],
+        ],
+        'required' => [
+          'select[name="sheet_type"]' => ['value' => 'enrollment'],
+        ],
+      ],
+    ];
+
+    $form['summary_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Summary sheet'),
+      '#description' => $this->t('Select the summary sheet to export.'),
+      '#options' => [
+        'producer' => $this->t('Producer Summary'),
+        'field' => $this->t('Field Summary'),
+      ],
+      '#states' => [
+        'visible' => [
+          'select[name="sheet_type"]' => ['value' => 'summary'],
+        ],
+        'required' => [
+          'select[name="sheet_type"]' => ['value' => 'summary'],
+        ],
+      ],
+    ];
+
+    $form['supplemental_type'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Supplemental sheet'),
+      '#description' => $this->t('Select the supplemental sheet to export.'),
+      '#options' => [
+        '528' => $this->t('Prescribed Grazing (528)'),
+      ],
+      '#states' => [
+        'visible' => [
+          'select[name="sheet_type"]' => ['value' => 'supplemental'],
+        ],
+        'required' => [
+          'select[name="sheet_type"]' => ['value' => 'supplemental'],
+        ],
+      ],
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+
+    // @TODO build data.
+    $data = [];
+
+    // Serialize the data as CSV.
+    $output = $this->serializer->serialize($data, 'csv');
+
+    // Prepare the file directory.
+    $directory = 'private://csv';
+    $this->fileSystem->prepareDirectory($directory, FileSystemInterface::CREATE_DIRECTORY);
+
+    // Create the file.
+    $date = date('c');
+    $filename = "$sheet_type-$date.csv";
+    $destination = "$directory/$filename";
+    try {
+      $file = $this->fileRepository->writeData($output, $destination);
+    }
+
+    // If file creation failed, bail with a warning.
+    catch (\Exception $e) {
+      $this->messenger()->addWarning($this->t('Could not create file.'));
+      return;
+    }
+
+    // Make the file temporary.
+    $file->status = 0;
+    $file->save();
+
+    // Add confirmation message.
+    if (count($this->entities)) {
+      $this->messenger()->addStatus($this->formatPlural(count($this->entities), 'Exported @count item.', 'Exported @count items'));
+    }
+
+    // Show a link to the file.
+    $url = $this->fileUrlGenerator->generateAbsoluteString($file->getFileUri());
+    $this->messenger()->addMessage($this->t('CSV file created: <a href=":url">%filename</a>', [
+      ':url' => $url,
+      '%filename' => $file->label(),
+    ]));
+
+    // Clean up the temporary storage.
+    $this->tempStore->delete($this->currentUser()->id());
+  }
+
+}

--- a/src/Form/PcscCsvActionForm.php
+++ b/src/Form/PcscCsvActionForm.php
@@ -327,22 +327,14 @@ class PcscCsvActionForm extends ConfirmFormBase {
    */
   public function exportEnrollmentProducer() {
     $data = [];
-    $data[] = [
-      'Farm ID',
-      'State or Territory',
-      'County',
-      'Producer data change',
-      'Producer start date',
-      'Producer name',
-    ];
     foreach ($this->entities as $entity) {
       $data[] = [
-        $entity->get('pcsc_farm_id')->value,
-        $entity->get('pcsc_state')->value,
-        $entity->get('pcsc_county')->value,
-        '',
-        '',
-        $entity->label(),
+        'Farm ID' => $entity->get('pcsc_farm_id')->value,
+        'State or Territory' => $entity->get('pcsc_state')->value,
+        'County' => $entity->get('pcsc_county')->value,
+        'Producer data change' => '',
+        'Producer start date' => '',
+        'Producer name' => $entity->label(),
       ];
     }
     return $data;
@@ -371,11 +363,11 @@ class PcscCsvActionForm extends ConfirmFormBase {
       ]);
       foreach ($fields as $field) {
         $data[] = [
-          $farm_id,
-          $field->get('pcsc_tract_id')->value,
-          $field->get('pcsc_field_id')->value,
-          $field->get('pcsc_state')->value,
-          $field->get('pcsc_county')->value,
+          'Farm ID' => $farm_id,
+          'Tract ID' => $field->get('pcsc_tract_id')->value,
+          'Field ID' => $field->get('pcsc_field_id')->value,
+          'State or Territory' => $field->get('pcsc_state')->value,
+          'County' => $field->get('pcsc_county')->value,
         ];
       }
 
@@ -391,14 +383,6 @@ class PcscCsvActionForm extends ConfirmFormBase {
    */
   public function exportSupplemental528() {
     $data = [];
-    $data[] = [
-      'Farm ID',
-      'Tract ID',
-      'Field ID',
-      'State or Territory',
-      'County',
-      'Grazing Type',
-    ];
     foreach ($this->entities as $entity) {
       $farm_id = $entity->get('pcsc_farm_id')->value;
       $practices = $this->entityTypeManager->getStorage('plan_record')->loadByProperties([
@@ -418,12 +402,12 @@ class PcscCsvActionForm extends ConfirmFormBase {
         $field = reset($fields);
 
         $data[] = [
-          $farm_id,
-          $field->get('pcsc_tract_id')->value,
-          $field->get('pcsc_field_id')->value,
-          $field->get('pcsc_state')->value,
-          $field->get('pcsc_county')->value,
-          $practice->get('528_grazing_type')->value,
+          'Farm ID' => $farm_id,
+          'Tract ID' => $field->get('pcsc_tract_id')->value,
+          'Field ID' => $field->get('pcsc_field_id')->value,
+          'State or Territory' => $field->get('pcsc_state')->value,
+          'County' => $field->get('pcsc_county')->value,
+          'Grazing Type' => $practice->get('528_grazing_type')->value,
         ];
       }
 

--- a/src/Plugin/Action/PcscCsv.php
+++ b/src/Plugin/Action/PcscCsv.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Drupal\farm_pcsc\Plugin\Action;
+
+use Drupal\Core\Action\Plugin\Action\EntityActionBase;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\Core\Session\AccountInterface;
+use Drupal\Core\TempStore\PrivateTempStoreFactory;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Action that exports CSV files for use in PCSC workbooks.
+ *
+ * @Action(
+ *   id = "farm_pcsc:csv_action",
+ *   action_label = @Translation("Export PCSC CSV"),
+ *   type = "plan",
+ *   confirm_form_route_name = "farm_pcsc.csv_action_form",
+ * )
+ */
+class PcscCsv extends EntityActionBase {
+
+  /**
+   * The tempstore object.
+   *
+   * @var \Drupal\Core\TempStore\SharedTempStore
+   */
+  protected $tempStore;
+
+  /**
+   * The current user.
+   *
+   * @var \Drupal\Core\Session\AccountInterface
+   */
+  protected $currentUser;
+
+  /**
+   * Constructs a new PcscCsv object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin ID for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager service.
+   * @param \Drupal\Core\TempStore\PrivateTempStoreFactory $temp_store_factory
+   *   The tempstore factory.
+   * @param \Drupal\Core\Session\AccountInterface $current_user
+   *   Current user.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, EntityTypeManagerInterface $entity_type_manager, PrivateTempStoreFactory $temp_store_factory, AccountInterface $current_user) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $entity_type_manager);
+    $this->tempStore = $temp_store_factory->get('pcsc_csv_confirm');
+    $this->currentUser = $current_user;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('entity_type.manager'),
+      $container->get('tempstore.private'),
+      $container->get('current_user'),
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function executeMultiple(array $entities) {
+    /** @var \Drupal\Core\Entity\EntityInterface[] $entities */
+    $this->tempStore->set($this->currentUser->id(), $entities);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function execute($object = NULL) {
+    $this->executeMultiple([$object]);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function access($object, AccountInterface $account = NULL, $return_as_object = FALSE) {
+    return $object->access('view', $account, $return_as_object);
+  }
+
+}


### PR DESCRIPTION
- Adds a general CSV export action for plans
- Implements initial CSV logic for producer + field enrollment and Prescribed Grazing 528 supplemental exports
- Adds a simple table view of PCSC Producers under the reports menu. These fields/filters could be expanded as more field storage is added

Right now these commits also include the 1.x-quick branch because that's what I used to populate data...