### PR TITLE
Supplemental csv exporters

### DIFF
--- a/src/Bundle/PcscFieldPractice327.php
+++ b/src/Bundle/PcscFieldPractice327.php
@@ -21,4 +21,13 @@ class PcscFieldPractice327 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Species category (select most common/extensive type if using more than one)' => $this->get('327_species_category')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice328.php
+++ b/src/Bundle/PcscFieldPractice328.php
@@ -2,6 +2,8 @@
 
 namespace Drupal\farm_pcsc\Bundle;
 
+use Drupal\Component\Utility\Html;
+
 /**
  * Provides the PCSC Field Practice 328 bundle class.
  */
@@ -24,11 +26,26 @@ class PcscFieldPractice328 extends PcscFieldPracticeBase {
       '#options' => $this->getListOptions('plan_record', $this->bundle(), '328_change_implemented'),
       '#required' => TRUE,
     ];
+
+    // Use unique ID because this field may appear for multiple practices.
+    $id =  Html::getUniqueId('328_rotation_tillage_type');
     $form['328_rotation_tillage_type'] = [
       '#type' => 'select',
       '#title' => $this->t('Conservation crop rotation tillage type'),
       '#options' => $this->getListOptions('plan_record', $this->bundle(), '328_rotation_tillage_type'),
       '#required' => TRUE,
+      '#attributes' => [
+        'id' => $id,
+      ],
+    ];
+    $form['328_rotation_tillage_type_other'] = [
+      '#type' => 'textfield',
+      '#title' => $this->t('Other conservation crop rotation tillage type'),
+      '#states' => [
+        'visible' => [
+          "select[id=\"$id\"]" => ['value' => 'Other (specify)'],
+        ],
+      ],
     ];
     $form['328_total_rotation_length'] = [
       '#type' => 'number',

--- a/src/Bundle/PcscFieldPractice328.php
+++ b/src/Bundle/PcscFieldPractice328.php
@@ -58,4 +58,17 @@ class PcscFieldPractice328 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Conservation crop type' => $this->get('328_crop_type')->value,
+      'Change implemented' => $this->get('328_change_implemented')->value,
+      'Conservation crop rotation tillage type' => $this->get('328_rotation_tillage_type')->value,
+      'Other conservation crop rotation tillage type' => $this->get('328_rotation_tillage_type_other')->value,
+      'Total conservation crop rotation length in days' => $this->get('328_total_rotation_length')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice329.php
+++ b/src/Bundle/PcscFieldPractice329.php
@@ -21,4 +21,13 @@ class PcscFieldPractice329 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Surface Disturbance' => $this->get('329_surface_disturbance')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice340.php
+++ b/src/Bundle/PcscFieldPractice340.php
@@ -34,4 +34,15 @@ class PcscFieldPractice340 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Species category (select most common/extensive type # if using more than one)' => $this->get('340_species_category')->value,
+      'Cover crop planned management' => $this->get('340_planned_management')->value,
+      'Cover crop termination method' => $this->get('340_termination_method')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice345.php
+++ b/src/Bundle/PcscFieldPractice345.php
@@ -21,4 +21,13 @@ class PcscFieldPractice345 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Surface Disturbance' => $this->get('345_surface_disturbance')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice484.php
+++ b/src/Bundle/PcscFieldPractice484.php
@@ -29,4 +29,14 @@ class PcscFieldPractice484 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Mulch Type' => $this->get('484_mulch_type')->value,
+      'Mulch cover (percent of field)' => $this->get('484_mulch_cover')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice528.php
+++ b/src/Bundle/PcscFieldPractice528.php
@@ -21,4 +21,13 @@ class PcscFieldPractice528 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Grazing Type' => $this->get('528_grazing_type')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPractice590.php
+++ b/src/Bundle/PcscFieldPractice590.php
@@ -65,4 +65,20 @@ class PcscFieldPractice590 extends PcscFieldPracticeBase {
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [
+      'Nutrient type with CPS 590' => $this->get('590_nutrient_type')->value,
+      'Nutrient application method with CPS 590' => $this->get('590_application_method')->value,
+      'Nutrient application method in the previous year' => $this->get('590_previous_application_method')->value,
+      'Nutrient application timing with CPS 590' => $this->get('590_timing')->value,
+      'Nutrient application timing in the previous year' => $this->get('590_previous_timing')->value,
+      'Nutrient application rate with CPS 590' => $this->get('590_rate')->value,
+      'Nutrient application rate unit with CPS 590' => $this->get('590_rate_unit')->value,
+      'Nutrient application rate change' => $this->get('590_rate_change')->value,
+    ];
+  }
+
 }

--- a/src/Bundle/PcscFieldPracticeBase.php
+++ b/src/Bundle/PcscFieldPracticeBase.php
@@ -81,4 +81,11 @@ abstract class PcscFieldPracticeBase extends PlanRecord implements PcscFieldPrac
     return $form;
   }
 
+  /**
+   * {@inheritdoc}
+   */
+  public function buildSupplementalFieldPracticeExport(): array {
+    return [];
+  }
+
 }

--- a/src/Bundle/PcscFieldPracticeInterface.php
+++ b/src/Bundle/PcscFieldPracticeInterface.php
@@ -21,4 +21,14 @@ interface PcscFieldPracticeInterface extends PlanRecordInterface {
    */
   public function buildPracticeForm(int $delta = 1): array;
 
+  /**
+   * Helper function to build the supplemental field practice data for export.
+   *
+   * This only includes the supplemental fields unique to this field practice.
+   *
+   * @return array
+   *   Array of supplement field practices data to include in export.
+   */
+  public function buildSupplementalFieldPracticeExport(): array;
+
 }

--- a/src/Form/PcscCsvActionForm.php
+++ b/src/Form/PcscCsvActionForm.php
@@ -244,7 +244,14 @@ class PcscCsvActionForm extends ConfirmFormBase {
       '#title' => $this->t('Supplemental sheet'),
       '#description' => $this->t('Select the supplemental sheet to export.'),
       '#options' => [
+        '327' => $this->t('Conservation Cover (327)'),
+        '328' => $this->t('Conservation Cover Rotation (328)'),
+        '329' => $this->t('Residue and Tillage Management, No Till (329)'),
+        '340' => $this->t('Cover Crop (340)'),
+        '345' => $this->t('Residue and Tillage Management, Reduced Till (345)'),
+        '484' => $this->t('Mulching (484)'),
         '528' => $this->t('Prescribed Grazing (528)'),
+        '590' => $this->t('Nutrient Management (590)'),
       ],
       '#states' => [
         'visible' => [

--- a/src/Plugin/PlanRecord/PlanRecordType/PcscFieldPractice328.php
+++ b/src/Plugin/PlanRecord/PlanRecordType/PcscFieldPractice328.php
@@ -58,6 +58,10 @@ class PcscFieldPractice328 extends PcscFieldPracticeBase {
         ]),
         'required' => TRUE,
       ],
+      '328_rotation_tillage_type_other' => [
+        'type' => 'string',
+        'label' => $this->t('328: Other conservation crop rotation tillage type'),
+      ],
       '328_total_rotation_length' => [
         'type' => 'integer',
         'label' => $this->t('328: Total conservation crop rotation length in days'),


### PR DESCRIPTION
Implements CSV exports for all field practices

Also adds a missing `328_rotation_tillage_type_other` field