### PR TITLE
Add UI for farm and field summaries

### DIFF
--- a/config/optional/views.view.pcsc_farm_summaries.yml
+++ b/config/optional/views.view.pcsc_farm_summaries.yml
@@ -1,0 +1,937 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - plan.record.type.pcsc_farm_summary
+    - plan.type.pcsc_producer
+  module:
+    - options
+    - plan
+    - user
+id: pcsc_farm_summaries
+label: 'PCSC Farm Summaries'
+module: views
+description: ''
+tag: ''
+base_table: plan_record
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'PCSC Farm Summaries'
+      fields:
+        view_plan_record:
+          id: view_plan_record
+          table: plan_record
+          field: view_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: View
+          output_url_as_text: false
+          absolute: false
+        edit_plan_record:
+          id: edit_plan_record
+          table: plan_record
+          field: edit_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link_edit
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Edit
+          output_url_as_text: false
+          absolute: true
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: field
+          label: 'Enrollment year'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: field
+          label: 'Enrollment quarter'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_incentive_amount_value:
+          id: pcsc_incentive_amount_value
+          table: plan_record__pcsc_incentive_amount
+          field: pcsc_incentive_amount_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_incentive_amount
+          plugin_id: field
+          label: 'Producer incentive amount'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_enrollment_value:
+          id: pcsc_payment_enrollment_value
+          table: plan_record__pcsc_payment_enrollment
+          field: pcsc_payment_enrollment_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_enrollment
+          plugin_id: field
+          label: 'Payment on enrollment'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_harvest_value:
+          id: pcsc_payment_harvest_value
+          table: plan_record__pcsc_payment_harvest
+          field: pcsc_payment_harvest_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_harvest
+          plugin_id: field
+          label: 'Payment on harvest'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_implementation_value:
+          id: pcsc_payment_implementation_value
+          table: plan_record__pcsc_payment_implementation
+          field: pcsc_payment_implementation_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_implementation
+          plugin_id: field
+          label: 'Payment on implementation'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_mmrv_value:
+          id: pcsc_payment_mmrv_value
+          table: plan_record__pcsc_payment_mmrv
+          field: pcsc_payment_mmrv_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_mmrv
+          plugin_id: field
+          label: 'Payment on MMRV'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_sale_value:
+          id: pcsc_payment_sale_value
+          table: plan_record__pcsc_payment_sale
+          field: pcsc_payment_sale_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_sale
+          plugin_id: field
+          label: 'Payment on sale'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view any pcsc_producer plan'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No Farm summaries. <a href="/quick/pcsc_farm_summary">Create Farm summary</a>'
+            format: default
+          tokenize: false
+      sorts:
+        id:
+          id: id
+          table: plan_record
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: id
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: numeric
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:plan'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              pcsc_producer: pcsc_producer
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
+      filters:
+        type:
+          id: type
+          table: plan_record
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            pcsc_farm_summary: pcsc_farm_summary
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            view_plan_record: view_plan_record
+            edit_plan_record: edit_plan_record
+            pcsc_year_value: pcsc_year_value
+            pcsc_quarter_value: pcsc_quarter_value
+            pcsc_incentive_amount_value: pcsc_incentive_amount_value
+            pcsc_payment_enrollment_value: pcsc_payment_enrollment_value
+            pcsc_payment_harvest_value: pcsc_payment_harvest_value
+            pcsc_payment_implementation_value: pcsc_payment_implementation_value
+            pcsc_payment_mmrv_value: pcsc_payment_mmrv_value
+            pcsc_payment_sale_value: pcsc_payment_sale_value
+          default: pcsc_year_value
+          info:
+            view_plan_record:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_plan_record:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_year_value:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_quarter_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_incentive_amount_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_payment_enrollment_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_payment_harvest_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_payment_implementation_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_payment_mmrv_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_payment_sale_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships: {  }
+      use_ajax: false
+      header: {  }
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: true
+          content: 'Displaying @start - @end of @total'
+      display_extenders:
+        collapsible_filter:
+          collapsible: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  block:
+    id: block
+    display_title: Block
+    display_plugin: block
+    position: 2
+    display_options:
+      display_extenders:
+        collapsible_filter:
+          collapsible: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/optional/views.view.pcsc_farm_summaries.yml
+++ b/config/optional/views.view.pcsc_farm_summaries.yml
@@ -786,6 +786,55 @@ display:
             default_group: All
             default_group_multiple: {  }
             group_items: {  }
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            label: Plan
+            description: null
+            use_operator: false
+            operator: plan_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: plan
+            required: false
+            remember: false
+            multiple: false
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: 'default:plan'
+          widget: autocomplete
+          handler_settings:
+            target_bundles:
+              pcsc_producer: pcsc_producer
+            sort:
+              field: _none
+              direction: ASC
+            auto_create: false
+            auto_create_bundle: ''
       style:
         type: table
         options:
@@ -926,6 +975,1164 @@ display:
       display_extenders:
         collapsible_filter:
           collapsible: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  page:
+    id: page
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      fields:
+        view_plan_record:
+          id: view_plan_record
+          table: plan_record
+          field: view_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: View
+          output_url_as_text: false
+          absolute: false
+        edit_plan_record:
+          id: edit_plan_record
+          table: plan_record
+          field: edit_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link_edit
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Edit
+          output_url_as_text: false
+          absolute: true
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: field
+          label: Producer
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: field
+          label: 'Enrollment year'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: field
+          label: 'Enrollment quarter'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_incentive_amount_value:
+          id: pcsc_incentive_amount_value
+          table: plan_record__pcsc_incentive_amount
+          field: pcsc_incentive_amount_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_incentive_amount
+          plugin_id: field
+          label: 'Producer incentive amount'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_enrollment_value:
+          id: pcsc_payment_enrollment_value
+          table: plan_record__pcsc_payment_enrollment
+          field: pcsc_payment_enrollment_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_enrollment
+          plugin_id: field
+          label: 'Payment on enrollment'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_harvest_value:
+          id: pcsc_payment_harvest_value
+          table: plan_record__pcsc_payment_harvest
+          field: pcsc_payment_harvest_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_harvest
+          plugin_id: field
+          label: 'Payment on harvest'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_implementation_value:
+          id: pcsc_payment_implementation_value
+          table: plan_record__pcsc_payment_implementation
+          field: pcsc_payment_implementation_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_implementation
+          plugin_id: field
+          label: 'Payment on implementation'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_mmrv_value:
+          id: pcsc_payment_mmrv_value
+          table: plan_record__pcsc_payment_mmrv
+          field: pcsc_payment_mmrv_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_mmrv
+          plugin_id: field
+          label: 'Payment on MMRV'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_payment_sale_value:
+          id: pcsc_payment_sale_value
+          table: plan_record__pcsc_payment_sale
+          field: pcsc_payment_sale_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_sale
+          plugin_id: field
+          label: 'Payment on sale'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      arguments: {  }
+      filters:
+        type:
+          id: type
+          table: plan_record
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            pcsc_farm_summary: pcsc_farm_summary
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: plan_op
+            label: Producer
+            description: ''
+            use_operator: false
+            operator: plan_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: plan
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: 'default:plan'
+          widget: autocomplete
+          handler_settings:
+            target_bundles:
+              pcsc_producer: pcsc_producer
+            sort:
+              field: _none
+              direction: ASC
+            auto_create: false
+            auto_create_bundle: ''
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_year_value_op
+            label: 'Enrollment year'
+            description: ''
+            use_operator: false
+            operator: pcsc_year_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_year_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_quarter_value_op
+            label: 'Enrollment quarter'
+            description: ''
+            use_operator: false
+            operator: pcsc_quarter_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_quarter_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        pcsc_payment_enrollment_value:
+          id: pcsc_payment_enrollment_value
+          table: plan_record__pcsc_payment_enrollment
+          field: pcsc_payment_enrollment_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_enrollment
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_payment_enrollment_value_op
+            label: 'Payment on enrollment'
+            description: ''
+            use_operator: false
+            operator: pcsc_payment_enrollment_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_payment_enrollment_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        pcsc_payment_harvest_value:
+          id: pcsc_payment_harvest_value
+          table: plan_record__pcsc_payment_harvest
+          field: pcsc_payment_harvest_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_harvest
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_payment_harvest_value_op
+            label: 'Payment on harvest'
+            description: ''
+            use_operator: false
+            operator: pcsc_payment_harvest_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_payment_harvest_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        pcsc_payment_implementation_value:
+          id: pcsc_payment_implementation_value
+          table: plan_record__pcsc_payment_implementation
+          field: pcsc_payment_implementation_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_implementation
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_payment_implementation_value_op
+            label: 'Payment on implementation'
+            description: ''
+            use_operator: false
+            operator: pcsc_payment_implementation_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_payment_implementation_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        pcsc_payment_mmrv_value:
+          id: pcsc_payment_mmrv_value
+          table: plan_record__pcsc_payment_mmrv
+          field: pcsc_payment_mmrv_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_mmrv
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_payment_mmrv_value_op
+            label: 'Payment on MMRV'
+            description: ''
+            use_operator: false
+            operator: pcsc_payment_mmrv_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_payment_mmrv_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        pcsc_payment_sale_value:
+          id: pcsc_payment_sale_value
+          table: plan_record__pcsc_payment_sale
+          field: pcsc_payment_sale_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_payment_sale
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_payment_sale_value_op
+            label: 'Payment on sale'
+            description: ''
+            use_operator: false
+            operator: pcsc_payment_sale_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_payment_sale_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      display_extenders:
+        collapsible_filter:
+          collapsible: true
+      path: report/pcsc-farm-summaries
     cache_metadata:
       max-age: -1
       contexts:

--- a/config/optional/views.view.pcsc_field_summaries.yml
+++ b/config/optional/views.view.pcsc_field_summaries.yml
@@ -1049,3 +1049,1092 @@ display:
         - url.query_args
         - user.permissions
       tags: {  }
+  page:
+    id: page
+    display_title: Page
+    display_plugin: page
+    position: 1
+    display_options:
+      fields:
+        view_plan_record:
+          id: view_plan_record
+          table: plan_record
+          field: view_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: View
+          output_url_as_text: false
+          absolute: false
+        edit_plan_record:
+          id: edit_plan_record
+          table: plan_record
+          field: edit_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link_edit
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Edit
+          output_url_as_text: false
+          absolute: true
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: pcsc_field_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: field
+          label: Producer
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_field_target_id:
+          id: pcsc_field_target_id
+          table: plan_record__pcsc_field
+          field: pcsc_field_target_id
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_field
+          plugin_id: field
+          label: 'Field Enrollment'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_commodity_type_value:
+          id: pcsc_commodity_type_value
+          table: plan_record__pcsc_commodity_type
+          field: pcsc_commodity_type_value
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_commodity_type
+          plugin_id: field
+          label: 'Commodity type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: field
+          label: 'Enrollment year'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: field
+          label: 'Enrollment quarter'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_practice_complete_value:
+          id: pcsc_practice_complete_value
+          table: plan_record__pcsc_practice_complete
+          field: pcsc_practice_complete_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_practice_complete
+          plugin_id: field
+          label: 'Date practice complete'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_end_date_value:
+          id: pcsc_end_date_value
+          table: plan_record__pcsc_end_date
+          field: pcsc_end_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_end_date
+          plugin_id: field
+          label: 'Contract end date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_field_commodity_value_value:
+          id: pcsc_field_commodity_value_value
+          table: plan_record__pcsc_field_commodity_value
+          field: pcsc_field_commodity_value_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_field_commodity_value
+          plugin_id: field
+          label: 'Field commodity value'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_implementation_cost_value:
+          id: pcsc_implementation_cost_value
+          table: plan_record__pcsc_implementation_cost
+          field: pcsc_implementation_cost_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_implementation_cost
+          plugin_id: field
+          label: 'Cost of implementation'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_implementation_cost_unit_value:
+          id: pcsc_implementation_cost_unit_value
+          table: plan_record__pcsc_implementation_cost_unit
+          field: pcsc_implementation_cost_unit_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_implementation_cost_unit
+          plugin_id: field
+          label: 'Cost of implementation unit'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      arguments: {  }
+      filters:
+        type:
+          id: type
+          table: plan_record
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            pcsc_field_summary: pcsc_field_summary
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        plan:
+          id: plan
+          table: plan_record
+          field: plan
+          relationship: pcsc_field_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: plan
+          plugin_id: entity_reference
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: plan_op
+            label: Producer
+            description: ''
+            use_operator: false
+            operator: plan_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: plan
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+          handler: 'default:plan'
+          widget: autocomplete
+          handler_settings:
+            target_bundles:
+              pcsc_producer: pcsc_producer
+            sort:
+              field: _none
+              direction: ASC
+            auto_create: false
+            auto_create_bundle: ''
+        pcsc_commodity_type_value:
+          id: pcsc_commodity_type_value
+          table: plan_record__pcsc_commodity_type
+          field: pcsc_commodity_type_value
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_commodity_type
+          plugin_id: list_field
+          operator: or
+          value: {  }
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_commodity_type_value_op
+            label: 'Commodity type'
+            description: ''
+            use_operator: false
+            operator: pcsc_commodity_type_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_commodity_type_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          reduce_duplicates: false
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_year_value_op
+            label: 'Enrollment year'
+            description: ''
+            use_operator: false
+            operator: pcsc_year_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_year_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: numeric
+          operator: '='
+          value:
+            min: ''
+            max: ''
+            value: ''
+          group: 1
+          exposed: true
+          expose:
+            operator_id: pcsc_quarter_value_op
+            label: 'Enrollment quarter'
+            description: ''
+            use_operator: false
+            operator: pcsc_quarter_value_op
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: pcsc_quarter_value
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              farm_manager: '0'
+              farm_pcsc_tap: '0'
+              farm_viewer: '0'
+              farm_worker: '0'
+            min_placeholder: ''
+            max_placeholder: ''
+            placeholder: ''
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      filter_groups:
+        operator: AND
+        groups:
+          1: AND
+      defaults:
+        relationships: false
+        fields: false
+        arguments: false
+        filters: false
+        filter_groups: false
+      relationships:
+        pcsc_commodity_target_id:
+          id: pcsc_commodity_target_id
+          table: plan_record__pcsc_commodity
+          field: pcsc_commodity_target_id
+          relationship: none
+          group_type: group
+          admin_label: Commodity
+          entity_type: plan_record
+          entity_field: pcsc_commodity
+          plugin_id: standard
+          required: false
+        pcsc_field_target_id:
+          id: pcsc_field_target_id
+          table: plan_record__pcsc_field
+          field: pcsc_field_target_id
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: 'Field enrollment'
+          entity_type: plan_record
+          entity_field: pcsc_field
+          plugin_id: standard
+          required: false
+      display_extenders:
+        collapsible_filter:
+          collapsible: true
+      path: report/pcsc-field-summaries
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/config/optional/views.view.pcsc_field_summaries.yml
+++ b/config/optional/views.view.pcsc_field_summaries.yml
@@ -1,0 +1,1051 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - plan.record.type.pcsc_field
+    - plan.record.type.pcsc_field_summary
+  module:
+    - options
+    - plan
+    - user
+id: pcsc_field_summaries
+label: 'PCSC Field Summaries'
+module: views
+description: ''
+tag: ''
+base_table: plan_record
+base_field: id
+display:
+  default:
+    id: default
+    display_title: Default
+    display_plugin: default
+    position: 0
+    display_options:
+      title: 'PCSC Field Summaries'
+      fields:
+        view_plan_record:
+          id: view_plan_record
+          table: plan_record
+          field: view_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: View
+          output_url_as_text: false
+          absolute: false
+        edit_plan_record:
+          id: edit_plan_record
+          table: plan_record
+          field: edit_plan_record
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          plugin_id: entity_link_edit
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          text: Edit
+          output_url_as_text: false
+          absolute: true
+        pcsc_field_target_id:
+          id: pcsc_field_target_id
+          table: plan_record__pcsc_field
+          field: pcsc_field_target_id
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_field
+          plugin_id: field
+          label: 'Field Enrollment'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_commodity_type_value:
+          id: pcsc_commodity_type_value
+          table: plan_record__pcsc_commodity_type
+          field: pcsc_commodity_type_value
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_commodity_type
+          plugin_id: field
+          label: 'Commodity type'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_year_value:
+          id: pcsc_year_value
+          table: plan_record__pcsc_year
+          field: pcsc_year_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_year
+          plugin_id: field
+          label: 'Enrollment year'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_quarter_value:
+          id: pcsc_quarter_value
+          table: plan_record__pcsc_quarter
+          field: pcsc_quarter_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_quarter
+          plugin_id: field
+          label: 'Enrollment quarter'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_integer
+          settings:
+            thousand_separator: ''
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_practice_complete_value:
+          id: pcsc_practice_complete_value
+          table: plan_record__pcsc_practice_complete
+          field: pcsc_practice_complete_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_practice_complete
+          plugin_id: field
+          label: 'Date practice complete'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_end_date_value:
+          id: pcsc_end_date_value
+          table: plan_record__pcsc_end_date
+          field: pcsc_end_date_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_end_date
+          plugin_id: field
+          label: 'Contract end date'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: timestamp
+          settings:
+            date_format: html_date
+            custom_date_format: ''
+            timezone: ''
+            tooltip:
+              date_format: long
+              custom_date_format: ''
+            time_diff:
+              enabled: false
+              future_format: '@interval hence'
+              past_format: '@interval ago'
+              granularity: 2
+              refresh: 60
+              description: ''
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_field_commodity_value_value:
+          id: pcsc_field_commodity_value_value
+          table: plan_record__pcsc_field_commodity_value
+          field: pcsc_field_commodity_value_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_field_commodity_value
+          plugin_id: field
+          label: 'Field commodity value'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_implementation_cost_value:
+          id: pcsc_implementation_cost_value
+          table: plan_record__pcsc_implementation_cost
+          field: pcsc_implementation_cost_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_implementation_cost
+          plugin_id: field
+          label: 'Cost of implementation'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: number_decimal
+          settings:
+            thousand_separator: ','
+            decimal_separator: .
+            scale: 2
+            prefix_suffix: true
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        pcsc_implementation_cost_unit_value:
+          id: pcsc_implementation_cost_unit_value
+          table: plan_record__pcsc_implementation_cost_unit
+          field: pcsc_implementation_cost_unit_value
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_implementation_cost_unit
+          plugin_id: field
+          label: 'Cost of implementation unit'
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: list_default
+          settings: {  }
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+      pager:
+        type: none
+        options:
+          offset: 0
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      access:
+        type: perm
+        options:
+          perm: 'view any pcsc_producer plan'
+      cache:
+        type: none
+        options: {  }
+      empty:
+        area:
+          id: area
+          table: views
+          field: area
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: text
+          empty: true
+          content:
+            value: 'No Field summaries. <a href="/quick/pcsc_field_summary">Create Field summary</a>'
+            format: default
+          tokenize: false
+      sorts:
+        id:
+          id: id
+          table: plan_record
+          field: id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: id
+          plugin_id: standard
+          order: DESC
+          expose:
+            label: ''
+            field_identifier: ''
+          exposed: false
+      arguments:
+        pcsc_field_target_id:
+          id: pcsc_field_target_id
+          table: plan_record__pcsc_field
+          field: pcsc_field_target_id
+          relationship: pcsc_commodity_target_id
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: pcsc_field
+          plugin_id: numeric
+          default_action: empty
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: fixed
+          default_argument_options:
+            argument: ''
+          summary_options:
+            base_path: ''
+            count: true
+            override: false
+            items_per_page: 25
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: true
+          validate:
+            type: 'entity:plan_record'
+            fail: 'not found'
+          validate_options:
+            bundles:
+              pcsc_field: pcsc_field
+            access: true
+            operation: view
+            multiple: 0
+          break_phrase: false
+          not: false
+      filters:
+        type:
+          id: type
+          table: plan_record
+          field: type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          entity_type: plan_record
+          entity_field: type
+          plugin_id: bundle
+          operator: in
+          value:
+            pcsc_field_summary: pcsc_field_summary
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            operator_limit_selection: false
+            operator_list: {  }
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+            reduce: false
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+      style:
+        type: table
+        options:
+          grouping: {  }
+          row_class: ''
+          default_row_class: true
+          columns:
+            view_plan_record: view_plan_record
+            edit_plan_record: edit_plan_record
+            pcsc_field_target_id: pcsc_field_target_id
+            pcsc_commodity_type_value: pcsc_commodity_type_value
+            pcsc_year_value: pcsc_year_value
+            pcsc_quarter_value: pcsc_quarter_value
+            pcsc_practice_complete_value: pcsc_practice_complete_value
+            pcsc_end_date_value: pcsc_end_date_value
+            pcsc_field_commodity_value_value: pcsc_field_commodity_value_value
+            pcsc_implementation_cost_value: pcsc_implementation_cost_value
+            pcsc_implementation_cost_unit_value: pcsc_implementation_cost_unit_value
+          default: pcsc_year_value
+          info:
+            view_plan_record:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            edit_plan_record:
+              sortable: false
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_field_target_id:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_commodity_type_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_year_value:
+              sortable: true
+              default_sort_order: desc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_quarter_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_practice_complete_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_end_date_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_field_commodity_value_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_implementation_cost_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+            pcsc_implementation_cost_unit_value:
+              sortable: true
+              default_sort_order: asc
+              align: ''
+              separator: ''
+              empty_column: false
+              responsive: ''
+          override: true
+          sticky: false
+          summary: ''
+          empty_table: true
+          caption: ''
+          description: ''
+      row:
+        type: fields
+      query:
+        type: views_query
+        options:
+          query_comment: ''
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_tags: {  }
+      relationships:
+        pcsc_commodity_target_id:
+          id: pcsc_commodity_target_id
+          table: plan_record__pcsc_commodity
+          field: pcsc_commodity_target_id
+          relationship: none
+          group_type: group
+          admin_label: Commodity
+          entity_type: plan_record
+          entity_field: pcsc_commodity
+          plugin_id: standard
+          required: false
+      use_ajax: false
+      header: {  }
+      footer:
+        result:
+          id: result
+          table: views
+          field: result
+          relationship: none
+          group_type: group
+          admin_label: ''
+          plugin_id: result
+          empty: true
+          content: 'Displaying @start - @end of @total'
+      display_extenders:
+        collapsible_filter:
+          collapsible: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }
+  block:
+    id: block
+    display_title: Block
+    display_plugin: block
+    position: 2
+    display_options:
+      display_extenders:
+        collapsible_filter:
+          collapsible: false
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - url.query_args
+        - user.permissions
+      tags: {  }

--- a/farm_pcsc.links.menu.yml
+++ b/farm_pcsc.links.menu.yml
@@ -2,3 +2,12 @@ farm_pcsc.pcsc_report:
   title: PCSC Producers
   parent: farm.report
   route_name: view.pcsc_plan_report.page
+  weight: -10
+farm_pcsc.pcsc_report_farm_summaries:
+  title: PCSC Farm Summaries
+  parent: farm.report
+  route_name: view.pcsc_farm_summaries.page
+farm_pcsc.pcsc_report_field_summaries:
+  title: PCSC Field Summaries
+  parent: farm.report
+  route_name: view.pcsc_field_summaries.page

--- a/farm_pcsc.module
+++ b/farm_pcsc.module
@@ -14,6 +14,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\entity\Menu\DefaultEntityLocalTaskProvider;
 use Drupal\farm_entity_views\FarmEntityViewsData;
 use Drupal\farm_pcsc\Bundle\PcscCommodity;
+use Drupal\farm_pcsc\Bundle\PcscFarmSummary;
 use Drupal\farm_pcsc\Bundle\PcscField;
 use Drupal\farm_pcsc\Bundle\PcscFieldPractice327;
 use Drupal\farm_pcsc\Bundle\PcscFieldPractice328;
@@ -24,6 +25,7 @@ use Drupal\farm_pcsc\Bundle\PcscFieldPractice345;
 use Drupal\farm_pcsc\Bundle\PcscFieldPractice484;
 use Drupal\farm_pcsc\Bundle\PcscFieldPractice528;
 use Drupal\farm_pcsc\Bundle\PcscFieldPractice590;
+use Drupal\farm_pcsc\Bundle\PcscFieldSummary;
 
 /**
  * Implements hook_entity_type_build().
@@ -57,6 +59,8 @@ function farm_pcsc_plan_record_bundle_classes() {
   return [
     'pcsc_field' => PcscField::class,
     'pcsc_commodity' => PcscCommodity::class,
+    'pcsc_farm_summary' => PcscFarmSummary::class,
+    'pcsc_field_summary' => PcscFieldSummary::class,
     'pcsc_field_practice_327' => PcscFieldPractice327::class,
     'pcsc_field_practice_328' => PcscFieldPractice328::class,
     'pcsc_field_practice_329' => PcscFieldPractice329::class,

--- a/farm_pcsc.module
+++ b/farm_pcsc.module
@@ -99,6 +99,64 @@ function farm_pcsc_form_alter(&$form, FormStateInterface $form_state, $form_id) 
 }
 
 /**
+ * Implements hook_farm_ui_theme_region_items().
+ */
+function farm_pcsc_farm_ui_theme_region_items(string $entity_type) {
+  return [
+    'bottom' => [
+      'pcsc_farm_summaries_view',
+      'pcsc_field_summaries_view',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_ENTITY_TYPE_view().
+ */
+function farm_pcsc_plan_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {
+  if ($entity->bundle() === 'pcsc_producer' && $view_mode === 'full') {
+
+    // Add farm summaries.
+    $view = Drupal\views\Views::getView('pcsc_farm_summaries');
+    if (is_object($view)) {
+      $view->setDisplay('block');
+      $view->setArguments([$entity->id()]);
+      $view->execute();
+      $render_array = $view->render();
+
+      // Check to ensure the view results are not empty.
+      $build['pcsc_farm_summaries_view'] = [
+        '#type'   => 'details',
+        '#title'  => t('Farm Summaries'),
+        '#open'   => TRUE,
+        'content' => $render_array,
+      ];
+      // To ensure the render array is cached tag it with the configuration tags.
+      $build['#cache']['tags'] = $view->getCacheTags();
+    }
+
+    // Add field summaries.
+    $view = Drupal\views\Views::getView('pcsc_field_summaries');
+    if (is_object($view)) {
+      $view->setDisplay('block');
+      $view->setArguments([$entity->id()]);
+      $view->execute();
+      $render_array = $view->render();
+
+      // Check to ensure the view results are not empty.
+      $build['pcsc_field_summaries_view'] = [
+        '#type'   => 'details',
+        '#title'  => t('Field Summaries'),
+        '#open'   => TRUE,
+        'content' => $render_array,
+      ];
+      // To ensure the render array is cached tag it with the configuration tags.
+      $build['#cache']['tags'] = $view->getCacheTags();
+    }
+  }
+}
+
+/**
  * Implements hook_ENTITY_TYPE_view().
  */
 function farm_pcsc_plan_record_view(array &$build, EntityInterface $entity, EntityViewDisplayInterface $display, $view_mode) {

--- a/src/Bundle/PcscCommodity.php
+++ b/src/Bundle/PcscCommodity.php
@@ -21,7 +21,7 @@ class PcscCommodity extends PlanRecord {
 
     // Build label with the referenced field.
     if ($field = $this->get('pcsc_field')->first()?->entity) {
-      return $this->t('Commodity %commodity: %field', ['%commodity' => $this->get('pcsc_commodity_type')->value, '%field' => $field->label()]);
+      return $this->t('Commodity @commodity: @field', ['@commodity' => $this->get('pcsc_commodity_type')->value, '@field' => $field->label()]);
     }
 
     // Fallback to default.

--- a/src/Bundle/PcscFarmSummary.php
+++ b/src/Bundle/PcscFarmSummary.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\farm_pcsc\Bundle;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\farm_pcsc\Traits\ListStringTrait;
+use Drupal\plan\Entity\PlanRecord;
+
+/**
+ * Base class for PCSC Farm Summary plan record types.
+ */
+class PcscFarmSummary extends PlanRecord {
+
+  use StringTranslationTrait;
+  use ListStringTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+
+    // Build label with the referenced field.
+    if ($plan = $this->get('plan')->first()?->entity) {
+      $quarter = "{$this->get('pcsc_year')->value}-{$this->get('pcsc_quarter')->value}";
+      return $this->t('Farm Summary @quarter: @producer', ['@quarter' => $quarter, '@producer' => $plan->label()]);
+    }
+
+    // Fallback to default.
+    return parent::label();
+  }
+
+}

--- a/src/Bundle/PcscField.php
+++ b/src/Bundle/PcscField.php
@@ -21,7 +21,7 @@ class PcscField extends PlanRecord {
 
     // Build label with the referenced field.
     if ($field = $this->get('field')->first()?->entity) {
-      return $this->t('Field enrollment: %field', ['%field' => $field->label()]);
+      return $this->t('Field enrollment: @field', ['@field' => $field->label()]);
     }
 
     // Fallback to default.

--- a/src/Bundle/PcscFieldPracticeBase.php
+++ b/src/Bundle/PcscFieldPracticeBase.php
@@ -21,7 +21,7 @@ abstract class PcscFieldPracticeBase extends PlanRecord implements PcscFieldPrac
 
     // Build label with the referenced field and practice type.
     if ($field = $this->get('pcsc_field')->first()?->entity) {
-      return $this->t('%practice: %field', ['%practice' => $this->getBundleLabel(), '%field' => $field->label()]);
+      return $this->t('@practice: @field', ['@practice' => $this->getBundleLabel(), '@field' => $field->label()]);
     }
 
     // Fallback to default.

--- a/src/Bundle/PcscFieldSummary.php
+++ b/src/Bundle/PcscFieldSummary.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Drupal\farm_pcsc\Bundle;
+
+use Drupal\Core\StringTranslation\StringTranslationTrait;
+use Drupal\farm_pcsc\Traits\ListStringTrait;
+use Drupal\plan\Entity\PlanRecord;
+
+/**
+ * Base class for PCSC Field Summary plan record types.
+ */
+class PcscFieldSummary extends PlanRecord {
+
+  use StringTranslationTrait;
+  use ListStringTrait;
+
+  /**
+   * {@inheritdoc}
+   */
+  public function label() {
+
+    // Build label with the referenced field.
+    if ($commodity = $this->get('pcsc_commodity')->first()?->entity) {
+      $quarter = "{$this->get('pcsc_year')->value}-{$this->get('pcsc_quarter')->value}";
+      return $this->t('Field Summary @quarter: @commodity', ['@quarter' => $quarter, '@commodity' => $commodity->label()]);
+    }
+
+    // Fallback to default.
+    return parent::label();
+  }
+
+}

--- a/src/Plugin/PlanRecord/PlanRecordType/PcscFieldSummary.php
+++ b/src/Plugin/PlanRecord/PlanRecordType/PcscFieldSummary.php
@@ -23,6 +23,7 @@ class PcscFieldSummary extends FarmPlanRecordType {
 
     $fields['pcsc_commodity'] = BundleFieldDefinition::create('entity_reference')
       ->setLabel(t('Field Commodity'))
+      ->setDescription(t('Relate this field summary with a commodity.'))
       ->setRequired(TRUE)
       ->setSetting('target_type', 'plan_record')
       ->setSetting('handler', 'default:plan_record')

--- a/src/Plugin/QuickForm/PcscCommodityEnrollment.php
+++ b/src/Plugin/QuickForm/PcscCommodityEnrollment.php
@@ -38,12 +38,14 @@ class PcscCommodityEnrollment extends QuickFormBase {
       '#title' => $this->t('Enrollment year'),
       '#options' => farm_pcsc_allowed_values_helper([2024, 2025, 2026, 2027, 2028]),
       '#default_value' => date('Y'),
+      '#required' => TRUE,
     ];
     $form['enrollment']['pcsc_quarter'] = [
       '#type' => 'select',
       '#title' => $this->t('Enrollment quarter'),
       '#options' => farm_pcsc_allowed_values_helper([1, 2, 3, 4]),
       '#default_value' => ceil(date('m') / 3),
+      '#required' => TRUE,
     ];
 
     $producers = \Drupal::entityTypeManager()->getStorage('plan')->loadByProperties(['type' => 'pcsc_producer']);

--- a/src/Plugin/QuickForm/PcscFieldEnrollment.php
+++ b/src/Plugin/QuickForm/PcscFieldEnrollment.php
@@ -261,7 +261,8 @@ class PcscFieldEnrollment extends QuickFormBase {
     }
 
     // Set a message and redirect to the list of fields.
-    $this->messenger()->addStatus($this->t('Field enrolled: @field', ['@field' => $land->label()]));
+    $entity_url = $field->toUrl()->setAbsolute()->toString();
+    $this->messenger()->addStatus($this->t('Field enrolled: <a href=":url">%label</a>', [':url' => $entity_url, '%label' => $field->label()]));
     $form_state->setRedirect('view.pcsc_producer_fields.page', ['plan' => $form_state->getValue('plan')]);
   }
 

--- a/src/Plugin/QuickForm/PcscFieldEnrollment.php
+++ b/src/Plugin/QuickForm/PcscFieldEnrollment.php
@@ -39,12 +39,14 @@ class PcscFieldEnrollment extends QuickFormBase {
       '#title' => $this->t('Enrollment year'),
       '#options' => farm_pcsc_allowed_values_helper([2024, 2025, 2026, 2027, 2028]),
       '#default_value' => date('Y'),
+      '#required' => TRUE,
     ];
     $form['enrollment']['pcsc_quarter'] = [
       '#type' => 'select',
       '#title' => $this->t('Enrollment quarter'),
       '#options' => farm_pcsc_allowed_values_helper([1, 2, 3, 4]),
       '#default_value' => ceil(date('m') / 3),
+      '#required' => TRUE,
     ];
 
     $producers = \Drupal::entityTypeManager()->getStorage('plan')->loadByProperties(['type' => 'pcsc_producer']);

--- a/src/Plugin/QuickForm/PcscFieldSummary.php
+++ b/src/Plugin/QuickForm/PcscFieldSummary.php
@@ -359,9 +359,10 @@ class PcscFieldSummary extends QuickFormBase {
     $summary = PlanRecord::create($record_values);
     $summary->save();
 
-    // Set a message and redirect to the list of fields.
-    $this->messenger()->addStatus($this->t('Field summary created: @summary', ['@summary' => $summary->label()]));
-    $form_state->setRedirect('view.pcsc_producer_fields.page', ['plan' => $form_state->getValue('plan')]);
+    // Set a message and redirect to the producer plan.
+    $entity_url = $summary->toUrl()->setAbsolute()->toString();
+    $this->messenger()->addStatus($this->t('Field summary created: <a href=":url">%label</a>', [':url' => $entity_url, '%label' => $summary->label()]));
+    $form_state->setRedirect('entity.plan_record.canonical', ['plan_record' => $form_state->getValue('field')]);
   }
 
 }

--- a/src/Plugin/QuickForm/PcscFieldSummary.php
+++ b/src/Plugin/QuickForm/PcscFieldSummary.php
@@ -353,6 +353,8 @@ class PcscFieldSummary extends QuickFormBase {
     // Create commodity record.
     $record_values = [
       'type' => 'pcsc_field_summary',
+      'pcsc_practice_complete' => strtotime($form_state->getValue('pcsc_practice_complete')),
+      'pcsc_end_date' => strtotime($form_state->getValue('pcsc_end_date')),
     ] + $form_state->getValues();
     $summary = PlanRecord::create($record_values);
     $summary->save();

--- a/src/Plugin/QuickForm/PcscFieldSummary.php
+++ b/src/Plugin/QuickForm/PcscFieldSummary.php
@@ -84,6 +84,22 @@ class PcscFieldSummary extends QuickFormBase {
       ],
     ];
 
+    $form['enrollment'] = $this->buildInlineContainer();
+    $form['enrollment']['pcsc_year'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enrollment year'),
+      '#options' => farm_pcsc_allowed_values_helper([2024, 2025, 2026, 2027, 2028]),
+      '#default_value' => date('Y'),
+      '#required' => TRUE,
+    ];
+    $form['enrollment']['pcsc_quarter'] = [
+      '#type' => 'select',
+      '#title' => $this->t('Enrollment quarter'),
+      '#options' => farm_pcsc_allowed_values_helper([1, 2, 3, 4]),
+      '#default_value' => ceil(date('m') / 3),
+      '#required' => TRUE,
+    ];
+
     $form['pcsc_practice_complete'] = [
       '#type' => 'date',
       '#title' => $this->t('Date practice complete'),

--- a/src/Plugin/QuickForm/PcscPractice.php
+++ b/src/Plugin/QuickForm/PcscPractice.php
@@ -129,9 +129,9 @@ class PcscPractice extends QuickFormBase {
       $practice->save();
     }
 
-    // Set a message and redirect to the list of practices.
+    // Set a message and redirect to the field enrollment.
     $this->messenger()->addStatus($this->t('@num_practices practices added.', ['@num_practices' => $values['num_practices']]));
-    $form_state->setRedirect('view.pcsc_field_practices.page', ['plan' => $values['plan'], 'asset' => $values['field']]);
+    $form_state->setRedirect('entity.plan_record.canonical', ['plan_record' => $form_state->getValue('pcsc_field')]);
   }
 
 }

--- a/src/Plugin/QuickForm/PcscPractice.php
+++ b/src/Plugin/QuickForm/PcscPractice.php
@@ -103,7 +103,7 @@ class PcscPractice extends QuickFormBase {
    * Ajax callback for field container.
    */
   public function fieldCallback(array $form, FormStateInterface $form_state) {
-    return $form['field'];
+    return $form['pcsc_field'];
   }
 
   /**

--- a/src/Plugin/QuickForm/PcscProducerEnrollment.php
+++ b/src/Plugin/QuickForm/PcscProducerEnrollment.php
@@ -37,12 +37,14 @@ class PcscProducerEnrollment extends QuickFormBase {
       '#title' => $this->t('Enrollment year'),
       '#options' => farm_pcsc_allowed_values_helper([2024, 2025, 2026, 2027, 2028]),
       '#default_value' => date('Y'),
+      '#required' => TRUE,
     ];
     $form['enrollment']['pcsc_quarter'] = [
       '#type' => 'select',
       '#title' => $this->t('Enrollment quarter'),
       '#options' => farm_pcsc_allowed_values_helper([1, 2, 3, 4]),
       '#default_value' => ceil(date('m') / 3),
+      '#required' => TRUE,
     ];
 
     $form['name'] = [


### PR DESCRIPTION
Adds UI for farm and field summaries. Fixes/improves a few other things:
- Add Farm summary quick form submit
- Farm and Field summaries are displayed in table views on the Producer plan page.
- Table views of Farm and Field summaries for all producers are included as new Reports